### PR TITLE
feat: implement NIP-06 basic key derivation from mnemonic seed phrase

### DIFF
--- a/docs/logs/20250603/2345-nip06.md
+++ b/docs/logs/20250603/2345-nip06.md
@@ -1,0 +1,44 @@
+# NIP-06 Implementation Log
+**Date**: December 6, 2025, 23:45
+**Task**: Implement NIP-06 basic key derivation from mnemonic seed phrase
+
+## Analysis of NIP-06 Requirements
+
+After reading the NIP-06 specification, I need to implement:
+
+### 1. BIP39 Support
+- Generate mnemonic seed words
+- Derive binary seed from mnemonic
+- Support for standard word lists
+
+### 2. BIP32 HD Key Derivation
+- Derive path: `m/44'/1237'/<account>'/0/0`
+- Hardened derivation for security
+- Support for multiple accounts (account increment)
+
+### 3. Key Generation Process
+1. Mnemonic phrase → Binary seed (BIP39)
+2. Binary seed → Master key (BIP32)
+3. Master key → Derived private key (using Nostr path)
+4. Private key → Public key (secp256k1)
+
+### 4. Encoding Support
+- Private key → nsec (bech32 encoding)
+- Public key → npub (bech32 encoding)
+- Hex representations for both
+
+### 5. Test Vectors
+Must pass the provided test vectors:
+- Test 1: "leader monkey parrot ring guide accident before fence cannon height naive bean"
+- Test 2: "what bleak badge arrange retreat wolf trade produce cricket blur garlic valid proud rude strong choose busy staff weather area salt hollow arm fade"
+
+## Implementation Plan
+
+1. **Install Dependencies**: @scure/bip32, @scure/bip39
+2. **Create Schemas**: Mnemonic, PrivateKey, PublicKey types with validation
+3. **Implement Key Derivation**: BIP39 → BIP32 → Nostr keys
+4. **Add Bech32 Encoding**: nsec/npub support using existing bech32 package
+5. **Comprehensive Tests**: Test vectors + edge cases
+6. **Integration**: Export from domain package
+
+Starting implementation...

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -27,6 +27,8 @@
     "@effect/platform": "0.84.5",
     "@effect/sql": "0.37.5",
     "@noble/secp256k1": "1.7.1",
+    "@scure/bip32": "1.7.0",
+    "@scure/bip39": "1.6.0",
     "bech32": "2.0.0",
     "effect": "3.16.3"
   },

--- a/packages/domain/src/Nip06.ts
+++ b/packages/domain/src/Nip06.ts
@@ -1,0 +1,195 @@
+import { Schema } from "effect"
+import * as bip39 from "@scure/bip39"
+import { wordlist } from "@scure/bip39/wordlists/english"
+import { HDKey } from "@scure/bip32"
+import { bech32 } from "bech32"
+import * as secp256k1 from "@noble/secp256k1"
+import { PubKey } from "./NostrEvent.js"
+
+// Nostr derivation path according to SLIP-44: m/44'/1237'/account'/0/0
+const NOSTR_DERIVATION_PATH_BASE = "m/44'/1237'"
+
+// Branded types for NIP-06
+export const Mnemonic = Schema.String.pipe(
+  Schema.pattern(/^(\w+\s){11}\w+$|^(\w+\s){14}\w+$|^(\w+\s){17}\w+$|^(\w+\s){20}\w+$|^(\w+\s){23}\w+$/), // 12, 15, 18, 21, or 24 words
+  Schema.brand("Mnemonic")
+)
+export type Mnemonic = typeof Mnemonic.Type
+
+export const PrivateKeyHex = Schema.String.pipe(
+  Schema.pattern(/^[a-f0-9]{64}$/),
+  Schema.brand("PrivateKeyHex")
+)
+export type PrivateKeyHex = typeof PrivateKeyHex.Type
+
+export const Nsec = Schema.String.pipe(
+  Schema.pattern(/^nsec1[a-z0-9]+$/),
+  Schema.brand("Nsec")
+)
+export type Nsec = typeof Nsec.Type
+
+export const Npub = Schema.String.pipe(
+  Schema.pattern(/^npub1[a-z0-9]+$/),
+  Schema.brand("Npub")
+)
+export type Npub = typeof Npub.Type
+
+export const Account = Schema.Number.pipe(
+  Schema.int(),
+  Schema.greaterThanOrEqualTo(0),
+  Schema.brand("Account")
+)
+export type Account = typeof Account.Type
+
+// NIP-06 Key Derivation class
+export class Nip06KeyDerivation {
+  /**
+   * Generate a new mnemonic phrase using BIP39
+   */
+  static generateMnemonic(strength: 128 | 160 | 192 | 224 | 256 = 128): Mnemonic {
+    const mnemonic = bip39.generateMnemonic(wordlist, strength)
+    return Mnemonic.make(mnemonic)
+  }
+
+  /**
+   * Validate a mnemonic phrase
+   */
+  static validateMnemonic(mnemonic: string): boolean {
+    return bip39.validateMnemonic(mnemonic, wordlist)
+  }
+
+  /**
+   * Derive a private key from mnemonic using NIP-06 specification
+   */
+  static derivePrivateKey(mnemonic: Mnemonic, account: Account = Account.make(0)): PrivateKeyHex {
+    // Validate mnemonic
+    if (!this.validateMnemonic(mnemonic)) {
+      throw new Error("Invalid mnemonic")
+    }
+
+    // Convert mnemonic to seed
+    const seed = bip39.mnemonicToSeedSync(mnemonic)
+    
+    // Create master key from seed
+    const masterKey = HDKey.fromMasterSeed(seed)
+    
+    // Derive key using Nostr path: m/44'/1237'/account'/0/0
+    const derivationPath = `${NOSTR_DERIVATION_PATH_BASE}/${account}'/0/0`
+    const derivedKey = masterKey.derive(derivationPath)
+    
+    if (!derivedKey.privateKey) {
+      throw new Error("Failed to derive private key")
+    }
+    
+    // Convert to hex string
+    const privateKeyHex = Buffer.from(derivedKey.privateKey).toString('hex')
+    return PrivateKeyHex.make(privateKeyHex)
+  }
+
+  /**
+   * Derive public key from private key
+   */
+  static derivePublicKey(privateKeyHex: PrivateKeyHex): PubKey {
+    const privateKeyBytes = Buffer.from(privateKeyHex, 'hex')
+    const publicKeyBytes = secp256k1.getPublicKey(privateKeyBytes, false) // uncompressed
+    
+    // For Nostr, we only want the x-coordinate (first 32 bytes after the 0x04 prefix)
+    // Uncompressed key format: 0x04 + 32 bytes x + 32 bytes y = 65 bytes total
+    const publicKeyHex = Buffer.from(publicKeyBytes.slice(1, 33)).toString('hex')
+    return PubKey.make(publicKeyHex)
+  }
+
+  /**
+   * Encode private key as nsec (bech32)
+   */
+  static encodeNsec(privateKeyHex: PrivateKeyHex): Nsec {
+    const privateKeyBytes = Buffer.from(privateKeyHex, 'hex')
+    const words = bech32.toWords(privateKeyBytes)
+    const encoded = bech32.encode('nsec', words)
+    return Nsec.make(encoded)
+  }
+
+  /**
+   * Decode nsec to private key hex
+   */
+  static decodeNsec(nsec: Nsec): PrivateKeyHex {
+    const decoded = bech32.decode(nsec)
+    if (decoded.prefix !== 'nsec') {
+      throw new Error('Invalid nsec prefix')
+    }
+    const privateKeyBytes = Buffer.from(bech32.fromWords(decoded.words))
+    const privateKeyHex = privateKeyBytes.toString('hex')
+    return PrivateKeyHex.make(privateKeyHex)
+  }
+
+  /**
+   * Encode public key as npub (bech32)
+   */
+  static encodeNpub(publicKeyHex: PubKey): Npub {
+    const publicKeyBytes = Buffer.from(publicKeyHex, 'hex')
+    const words = bech32.toWords(publicKeyBytes)
+    const encoded = bech32.encode('npub', words)
+    return Npub.make(encoded)
+  }
+
+  /**
+   * Decode npub to public key hex
+   */
+  static decodeNpub(npub: Npub): PubKey {
+    const decoded = bech32.decode(npub)
+    if (decoded.prefix !== 'npub') {
+      throw new Error('Invalid npub prefix')
+    }
+    const publicKeyBytes = Buffer.from(bech32.fromWords(decoded.words))
+    const publicKeyHex = publicKeyBytes.toString('hex')
+    return PubKey.make(publicKeyHex)
+  }
+
+  /**
+   * Complete key derivation from mnemonic to all formats
+   */
+  static deriveAllKeys(mnemonic: Mnemonic, account: Account = Account.make(0)) {
+    const privateKeyHex = this.derivePrivateKey(mnemonic, account)
+    const publicKeyHex = this.derivePublicKey(privateKeyHex)
+    const nsec = this.encodeNsec(privateKeyHex)
+    const npub = this.encodeNpub(publicKeyHex)
+
+    return {
+      mnemonic,
+      account,
+      privateKeyHex,
+      publicKeyHex,
+      nsec,
+      npub,
+      derivationPath: `${NOSTR_DERIVATION_PATH_BASE}/${account}'/0/0`
+    }
+  }
+}
+
+// Schema for the complete key derivation result
+export const KeyDerivationResult = Schema.Struct({
+  mnemonic: Mnemonic,
+  account: Account,
+  privateKeyHex: PrivateKeyHex,
+  publicKeyHex: PubKey,
+  nsec: Nsec,
+  npub: Npub,
+  derivationPath: Schema.String
+})
+export type KeyDerivationResult = typeof KeyDerivationResult.Type
+
+// Error types for NIP-06 operations
+export class InvalidMnemonicError extends Schema.TaggedError<InvalidMnemonicError>()("InvalidMnemonicError", {
+  mnemonic: Schema.String,
+  reason: Schema.String
+}) {}
+
+export class KeyDerivationError extends Schema.TaggedError<KeyDerivationError>()("KeyDerivationError", {
+  reason: Schema.String,
+  derivationPath: Schema.optional(Schema.String)
+}) {}
+
+export class EncodingError extends Schema.TaggedError<EncodingError>()("EncodingError", {
+  format: Schema.String,
+  reason: Schema.String
+}) {}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -3,5 +3,8 @@ export * from "./NostrEvent.js"
 export * from "./NostrMessages.js" 
 export * from "./NostrFilter.js"
 
+// Export NIP-06 key derivation
+export * from "./Nip06.js"
+
 // Export old TodosApi for backward compatibility during transition
 export * from "./TodosApi.js"

--- a/packages/domain/test/Nip06.test.ts
+++ b/packages/domain/test/Nip06.test.ts
@@ -1,0 +1,274 @@
+import { describe, test, expect } from "vitest"
+import { 
+  Nip06KeyDerivation,
+  Mnemonic,
+  PrivateKeyHex,
+  Nsec,
+  Npub,
+  Account
+} from "../src/Nip06.js"
+import { PubKey } from "../src/NostrEvent.js"
+
+describe("NIP-06 Key Derivation", () => {
+  describe("Test Vectors from NIP-06 Specification", () => {
+    test("Test Vector 1: leader monkey parrot...", () => {
+      const mnemonic = Mnemonic.make("leader monkey parrot ring guide accident before fence cannon height naive bean")
+      const expectedPrivateKey = "7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a"
+      const expectedNsec = "nsec10allq0gjx7fddtzef0ax00mdps9t2kmtrldkyjfs8l5xruwvh2dq0lhhkp"
+      const expectedPublicKey = "17162c921dc4d2518f9a101db33695df1afb56ab82f5ff3e5da6eec3ca5cd917"
+      const expectedNpub = "npub1zutzeysacnf9rru6zqwmxd54mud0k44tst6l70ja5mhv8jjumytsd2x7nu"
+
+      const result = Nip06KeyDerivation.deriveAllKeys(mnemonic, Account.make(0))
+
+      expect(result.privateKeyHex).toBe(expectedPrivateKey)
+      expect(result.nsec).toBe(expectedNsec)
+      expect(result.publicKeyHex).toBe(expectedPublicKey)
+      expect(result.npub).toBe(expectedNpub)
+      expect(result.account).toBe(0)
+      expect(result.derivationPath).toBe("m/44'/1237'/0'/0/0")
+    })
+
+    test("Test Vector 2: what bleak badge...", () => {
+      const mnemonic = Mnemonic.make("what bleak badge arrange retreat wolf trade produce cricket blur garlic valid proud rude strong choose busy staff weather area salt hollow arm fade")
+      const expectedPrivateKey = "c15d739894c81a2fcfd3a2df85a0d2c0dbc47a280d092799f144d73d7ae78add"
+      const expectedNsec = "nsec1c9wh8xy5eqdzln7n5t0ctgxjcrdug73gp5yj0x03gntn67h83twssdfhel"
+      const expectedPublicKey = "d41b22899549e1f3d335a31002cfd382174006e166d3e658e3a5eecdb6463573"
+      const expectedNpub = "npub16sdj9zv4f8sl85e45vgq9n7nsgt5qphpvmf7vk8r5hhvmdjxx4es8rq74h"
+
+      const result = Nip06KeyDerivation.deriveAllKeys(mnemonic, Account.make(0))
+
+      expect(result.privateKeyHex).toBe(expectedPrivateKey)
+      expect(result.nsec).toBe(expectedNsec)
+      expect(result.publicKeyHex).toBe(expectedPublicKey)
+      expect(result.npub).toBe(expectedNpub)
+      expect(result.account).toBe(0)
+      expect(result.derivationPath).toBe("m/44'/1237'/0'/0/0")
+    })
+  })
+
+  describe("Mnemonic Generation and Validation", () => {
+    test("should generate valid 12-word mnemonic", () => {
+      const mnemonic = Nip06KeyDerivation.generateMnemonic(128)
+      expect(mnemonic.split(' ')).toHaveLength(12)
+      expect(Nip06KeyDerivation.validateMnemonic(mnemonic)).toBe(true)
+    })
+
+    test("should generate valid 15-word mnemonic", () => {
+      const mnemonic = Nip06KeyDerivation.generateMnemonic(160)
+      expect(mnemonic.split(' ')).toHaveLength(15)
+      expect(Nip06KeyDerivation.validateMnemonic(mnemonic)).toBe(true)
+    })
+
+    test("should generate valid 18-word mnemonic", () => {
+      const mnemonic = Nip06KeyDerivation.generateMnemonic(192)
+      expect(mnemonic.split(' ')).toHaveLength(18)
+      expect(Nip06KeyDerivation.validateMnemonic(mnemonic)).toBe(true)
+    })
+
+    test("should generate valid 21-word mnemonic", () => {
+      const mnemonic = Nip06KeyDerivation.generateMnemonic(224)
+      expect(mnemonic.split(' ')).toHaveLength(21)
+      expect(Nip06KeyDerivation.validateMnemonic(mnemonic)).toBe(true)
+    })
+
+    test("should generate valid 24-word mnemonic", () => {
+      const mnemonic = Nip06KeyDerivation.generateMnemonic(256)
+      expect(mnemonic.split(' ')).toHaveLength(24)
+      expect(Nip06KeyDerivation.validateMnemonic(mnemonic)).toBe(true)
+    })
+
+    test("should validate correct mnemonic", () => {
+      const validMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+      expect(Nip06KeyDerivation.validateMnemonic(validMnemonic)).toBe(true)
+    })
+
+    test("should reject invalid mnemonic", () => {
+      const invalidMnemonic = "invalid mnemonic phrase with wrong words that do not exist"
+      expect(Nip06KeyDerivation.validateMnemonic(invalidMnemonic)).toBe(false)
+    })
+  })
+
+  describe("Key Derivation", () => {
+    test("should derive same keys from same mnemonic", () => {
+      const mnemonic = Mnemonic.make("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+      
+      const result1 = Nip06KeyDerivation.deriveAllKeys(mnemonic, Account.make(0))
+      const result2 = Nip06KeyDerivation.deriveAllKeys(mnemonic, Account.make(0))
+      
+      expect(result1.privateKeyHex).toBe(result2.privateKeyHex)
+      expect(result1.publicKeyHex).toBe(result2.publicKeyHex)
+      expect(result1.nsec).toBe(result2.nsec)
+      expect(result1.npub).toBe(result2.npub)
+    })
+
+    test("should derive different keys for different accounts", () => {
+      const mnemonic = Mnemonic.make("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+      
+      const result0 = Nip06KeyDerivation.deriveAllKeys(mnemonic, Account.make(0))
+      const result1 = Nip06KeyDerivation.deriveAllKeys(mnemonic, Account.make(1))
+      
+      expect(result0.privateKeyHex).not.toBe(result1.privateKeyHex)
+      expect(result0.publicKeyHex).not.toBe(result1.publicKeyHex)
+      expect(result0.nsec).not.toBe(result1.nsec)
+      expect(result0.npub).not.toBe(result1.npub)
+      expect(result0.derivationPath).toBe("m/44'/1237'/0'/0/0")
+      expect(result1.derivationPath).toBe("m/44'/1237'/1'/0/0")
+    })
+
+    test("should derive valid private keys", () => {
+      const mnemonic = Nip06KeyDerivation.generateMnemonic()
+      const privateKey = Nip06KeyDerivation.derivePrivateKey(mnemonic, Account.make(0))
+      
+      expect(privateKey).toMatch(/^[a-f0-9]{64}$/)
+      expect(privateKey.length).toBe(64)
+    })
+
+    test("should derive valid public keys from private keys", () => {
+      const mnemonic = Nip06KeyDerivation.generateMnemonic()
+      const privateKey = Nip06KeyDerivation.derivePrivateKey(mnemonic, Account.make(0))
+      const publicKey = Nip06KeyDerivation.derivePublicKey(privateKey)
+      
+      expect(publicKey).toMatch(/^[a-f0-9]{64}$/)
+      expect(publicKey.length).toBe(64)
+    })
+
+    test("should throw error for invalid mnemonic in derivation", () => {
+      const invalidMnemonic = "invalid mnemonic phrase" as any as Mnemonic
+      
+      expect(() => {
+        Nip06KeyDerivation.derivePrivateKey(invalidMnemonic, Account.make(0))
+      }).toThrow("Invalid mnemonic")
+    })
+  })
+
+  describe("Bech32 Encoding/Decoding", () => {
+    test("should encode and decode nsec correctly", () => {
+      const privateKeyHex = PrivateKeyHex.make("7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a")
+      const nsec = Nip06KeyDerivation.encodeNsec(privateKeyHex)
+      const decodedPrivateKey = Nip06KeyDerivation.decodeNsec(nsec)
+      
+      expect(nsec).toMatch(/^nsec1[a-z0-9]+$/)
+      expect(decodedPrivateKey).toBe(privateKeyHex)
+    })
+
+    test("should encode and decode npub correctly", () => {
+      const publicKeyHex = PubKey.make("17162c921dc4d2518f9a101db33695df1afb56ab82f5ff3e5da6eec3ca5cd917")
+      const npub = Nip06KeyDerivation.encodeNpub(publicKeyHex)
+      const decodedPublicKey = Nip06KeyDerivation.decodeNpub(npub)
+      
+      expect(npub).toMatch(/^npub1[a-z0-9]+$/)
+      expect(decodedPublicKey).toBe(publicKeyHex)
+    })
+
+    test("should validate nsec format", () => {
+      const validNsec = Nsec.make("nsec10allq0gjx7fddtzef0ax00mdps9t2kmtrldkyjfs8l5xruwvh2dq0lhhkp")
+      expect(validNsec).toBeDefined()
+    })
+
+    test("should validate npub format", () => {
+      const validNpub = Npub.make("npub1zutzeysacnf9rru6zqwmxd54mud0k44tst6l70ja5mhv8jjumytsd2x7nu")
+      expect(validNpub).toBeDefined()
+    })
+
+    test("should reject invalid nsec format", () => {
+      expect(() => Nsec.make("invalid")).toThrow()
+      expect(() => Nsec.make("npub1zutzeysacnf9rru6zqwmxd54mud0k44tst6l70ja5mhv8jjumytsd2x7nu")).toThrow()
+    })
+
+    test("should reject invalid npub format", () => {
+      expect(() => Npub.make("invalid")).toThrow()
+      expect(() => Npub.make("nsec10allq0gjx7fddtzef0ax00mdps9t2kmtrldkyjfs8l5xruwvh2dq0lhhkp")).toThrow()
+    })
+
+    test("should throw error for invalid nsec prefix in decode", () => {
+      const invalidNsec = "npub1zutzeysacnf9rru6zqwmxd54mud0k44tst6l70ja5mhv8jjumytsd2x7nu" as any as Nsec
+      
+      expect(() => {
+        Nip06KeyDerivation.decodeNsec(invalidNsec)
+      }).toThrow("Invalid nsec prefix")
+    })
+
+    test("should throw error for invalid npub prefix in decode", () => {
+      const invalidNpub = "nsec10allq0gjx7fddtzef0ax00mdps9t2kmtrldkyjfs8l5xruwvh2dq0lhhkp" as any as Npub
+      
+      expect(() => {
+        Nip06KeyDerivation.decodeNpub(invalidNpub)
+      }).toThrow("Invalid npub prefix")
+    })
+  })
+
+  describe("Account Handling", () => {
+    test("should support account numbers 0-999", () => {
+      const mnemonic = Mnemonic.make("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+      
+      const accounts = [0, 1, 10, 100, 999]
+      const results = accounts.map(acc => 
+        Nip06KeyDerivation.deriveAllKeys(mnemonic, Account.make(acc))
+      )
+      
+      // All accounts should produce different keys
+      const privateKeys = results.map(r => r.privateKeyHex)
+      const uniquePrivateKeys = new Set(privateKeys)
+      expect(uniquePrivateKeys.size).toBe(accounts.length)
+      
+      // Check derivation paths
+      expect(results[0].derivationPath).toBe("m/44'/1237'/0'/0/0")
+      expect(results[1].derivationPath).toBe("m/44'/1237'/1'/0/0")
+      expect(results[2].derivationPath).toBe("m/44'/1237'/10'/0/0")
+      expect(results[3].derivationPath).toBe("m/44'/1237'/100'/0/0")
+      expect(results[4].derivationPath).toBe("m/44'/1237'/999'/0/0")
+    })
+
+    test("should reject negative account numbers", () => {
+      expect(() => Account.make(-1)).toThrow()
+    })
+  })
+
+  describe("Edge Cases", () => {
+    test("should handle empty string gracefully", () => {
+      expect(Nip06KeyDerivation.validateMnemonic("")).toBe(false)
+    })
+
+    test("should handle single word gracefully", () => {
+      expect(Nip06KeyDerivation.validateMnemonic("abandon")).toBe(false)
+    })
+
+    test("should handle too many words gracefully", () => {
+      const tooManyWords = Array(25).fill("abandon").join(" ")
+      expect(Nip06KeyDerivation.validateMnemonic(tooManyWords)).toBe(false)
+    })
+
+    test("should handle words with extra spaces", () => {
+      const spacedMnemonic = "abandon  abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+      expect(Nip06KeyDerivation.validateMnemonic(spacedMnemonic)).toBe(false)
+    })
+  })
+
+  describe("Branded Types", () => {
+    test("should accept valid mnemonic patterns", () => {
+      const valid12 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+      const valid24 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+      
+      expect(() => Mnemonic.make(valid12)).not.toThrow()
+      expect(() => Mnemonic.make(valid24)).not.toThrow()
+    })
+
+    test("should reject invalid mnemonic patterns", () => {
+      expect(() => Mnemonic.make("")).toThrow()
+      expect(() => Mnemonic.make("one two")).toThrow()
+      expect(() => Mnemonic.make("too many words " + Array(20).fill("word").join(" "))).toThrow()
+    })
+
+    test("should accept valid private key hex", () => {
+      const validHex = "7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a"
+      expect(() => PrivateKeyHex.make(validHex)).not.toThrow()
+    })
+
+    test("should reject invalid private key hex", () => {
+      expect(() => PrivateKeyHex.make("invalid")).toThrow()
+      expect(() => PrivateKeyHex.make("7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9")).toThrow() // too short
+      expect(() => PrivateKeyHex.make("7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9aa")).toThrow() // too long
+      expect(() => PrivateKeyHex.make("GFFFFFF03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a")).toThrow() // invalid hex
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,12 @@ importers:
       '@noble/secp256k1':
         specifier: 1.7.1
         version: 1.7.1
+      '@scure/bip32':
+        specifier: 1.7.0
+        version: 1.7.0
+      '@scure/bip39':
+        specifier: 1.6.0
+        version: 1.6.0
       bech32:
         specifier: 2.0.0
         version: 2.0.0
@@ -885,6 +891,14 @@ packages:
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
 
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/secp256k1@1.7.1':
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
 
@@ -1100,6 +1114,15 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -3841,6 +3864,12 @@ snapshots:
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     optional: true
 
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
   '@noble/secp256k1@1.7.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3985,6 +4014,19 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sinclair/typebox@0.27.8': {}
 


### PR DESCRIPTION
## Summary
- Complete implementation of NIP-06 specification for basic key derivation from mnemonic seed phrase
- Supports BIP39 mnemonic generation/validation and BIP32 hierarchical deterministic key derivation
- Uses standard Nostr derivation path m/44'/1237'/account'/0/0 with multi-account support

## Implementation Details
- **Dependencies**: Added @scure/bip32@1.7.0 and @scure/bip39@1.6.0 for secure cryptographic operations
- **Key Features**: Mnemonic generation, private/public key derivation, bech32 nsec/npub encoding
- **Validation**: Includes all NIP-06 test vectors and comprehensive edge case testing
- **Type Safety**: Full Effect Schema integration with branded types for all key formats

## Test Coverage
- ✅ NIP-06 specification test vectors validated
- ✅ Mnemonic generation for 12, 15, 18, 21, 24 word phrases
- ✅ Key derivation consistency and multi-account support
- ✅ Bech32 encoding/decoding for nsec/npub formats
- ✅ Edge cases and error handling
- ✅ TypeScript compilation passes (pnpm check)
- ✅ All tests pass (pnpm test)

🤖 Generated with [Claude Code](https://claude.ai/code)